### PR TITLE
Fix: exclude collations which `Id` is null.

### DIFF
--- a/Driver.cs
+++ b/Driver.cs
@@ -350,7 +350,7 @@ internal partial class Driver : IDisposable
     private void LoadCharacterSets (MySqlConnection connection)
     {
         this.serverProps.TryGetValue ("autocommit", out string serverAutocommit);
-        MySqlCommand cmd = new MySqlCommand ("SHOW COLLATION", connection);
+        MySqlCommand cmd = new MySqlCommand ("SHOW COLLATION WHERE Id IS NOT NULL", connection);
 
         // now we load all the currently active collations
         try


### PR DESCRIPTION
These collations will cause error when calling `Driver.LoadCharacterSets()`